### PR TITLE
Fix leak in format_pcap.c

### DIFF
--- a/lib/format_pcap.c
+++ b/lib/format_pcap.c
@@ -362,6 +362,10 @@ static int pcap_pause_input(libtrace_t *libtrace)
 
 static int pcap_fin_input(libtrace_t *libtrace) 
 {
+	if (INPUT.pcap) {
+		pcap_close(INPUT.pcap);
+		INPUT.pcap=NULL;
+	}
 	free(libtrace->format_data);
 	return 0; /* success */
 }


### PR DESCRIPTION
INPUT.pcap was never closed because pcap_pause_input is not called for pcap file.