### PR TITLE
Allow parsing SIT (ipv6-in-ipv4) packets inside SLL

### DIFF
--- a/lib/linktypes.c
+++ b/lib/linktypes.c
@@ -211,6 +211,7 @@ libtrace_linktype_t arphrd_type_to_libtrace(unsigned int arphrd) {
 		case LIBTRACE_ARPHRD_IEEE80211_RADIOTAP: return TRACE_TYPE_80211_RADIO;
 		case LIBTRACE_ARPHRD_PPP: return TRACE_TYPE_NONE;
 		case LIBTRACE_ARPHRD_LOOPBACK: return TRACE_TYPE_ETH;
+		case LIBTRACE_ARPHRD_SIT: return TRACE_TYPE_ETH;
 		case LIBTRACE_ARPHRD_NONE: return TRACE_TYPE_NONE;
 	}
 	printf("Unknown ARPHRD %08x\n",arphrd);


### PR DESCRIPTION
This patch makes it possible to read tcpdump captured IPv6-in-IPv4 packets. It makes a reasonable(?) assumption of underlying layer is of type ethernet.

Fixes Unknown ARPHRD 00000308 messages during reads.