### PR TITLE
Add trace_clear_statistics api.

### DIFF
--- a/lib/libtrace.h.in
+++ b/lib/libtrace.h.in
@@ -1661,6 +1661,15 @@ void trace_get_thread_statistics(libtrace_t *trace, libtrace_thread_t *t,
 DLLEXPORT libtrace_stat_t* trace_create_statistics(void);
 
 /**
+ * Clear all fields of given statistic.
+ * This api doesn't verify the magic field unlike other stat apis.
+ *
+ * @param s The statistic structure to clear
+ */
+DLLEXPORT
+void trace_clear_statistics(libtrace_stat_t *s);
+
+/**
  * Performs the operation c=a-b accounting for valid fields.
  * c is allowed to be a or b.
  *

--- a/lib/trace.c
+++ b/lib/trace.c
@@ -2213,6 +2213,11 @@ libtrace_stat_t *trace_create_statistics(void) {
 	return ret;
 }
 
+void trace_clear_statistics(libtrace_stat_t *s) {
+	memset(s, 0, sizeof(libtrace_stat_t));
+	s->magic = LIBTRACE_STAT_MAGIC;
+}
+
 void trace_subtract_statistics(const libtrace_stat_t *a, const libtrace_stat_t *b,
                          libtrace_stat_t *c) {
 	assert(a->magic == LIBTRACE_STAT_MAGIC && "Please use"


### PR DESCRIPTION
This api fills zeroes and set magic field.
This api doesn't verify the magic field of given stat intentionally
so now stat can be used without create in heap and free.
ex) f() {
libtrace_stat_t stat;
trace_clear_statistics(&stat);
trace_get_statistics(trace, stat);
}